### PR TITLE
add redocly license key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,7 @@ jobs:
           GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
           GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }}
           GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
 
       - name: Deploy
@@ -257,6 +258,7 @@ jobs:
           GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
           GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }}
           GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
       - name: Deploy
         uses: AdobeDocs/static-website-deploy@master


### PR DESCRIPTION
## Description

Public repos under AdobeDocs (like this repo) automatically get access to [REDOCLY_LICENSE_KEY](https://github.com/organizations/AdobeDocs/settings/secrets/actions). This PR makes that key accessible to the `deploy.yml` (as described in the[ RedoclyAPIBlock readme](https://github.com/adobe/aio-theme?tab=readme-ov-file#on-premise-license-keys)).